### PR TITLE
VEP reports "lncRNA" "lincRNA" with different builds

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -118,6 +118,7 @@ sub GetBiotypePriority {
         'scaRNA' => 3, # Non-coding RNA predicted using sequences from RFAM and miRBase
         'rRNA' => 3, # Non-coding RNA predicted using sequences from RFAM and miRBase
         'lincRNA' => 3, # Long, intervening noncoding (linc) RNAs, that can be found in evolutionarily conserved, intergenic regions
+        'lncRNA' => 3, # Long, noncoding (lnc) RNAs  
         'bidirectional_promoter_lncrna' => 3, # A non-coding locus that originates from within the promoter region of a protein-coding gene, with transcription proceeding in the opposite direction on the other strand
         'bidirectional_promoter_lncRNA' => 3, # A non-coding locus that originates from within the promoter region of a protein-coding gene, with transcription proceeding in the opposite direction on the other strand
         'known_ncrna' => 4,


### PR DESCRIPTION
VEP appears have changed how they label long, non-coding RNA sequences depending on the build of their cache.  Under their version 97 of their cache, it labeled them "lincRNA" under GRCh37, and "lncRNA" under GRCh38.  Under version 100 of their refseq cache, they appear to be 'lncRNA' under both genome builds.  However, under version 100 of their regular cache, they are back to 'lincRNA' for GRCh37 and 'lncRNA' for GRCh38

You can check this by downloading their recent cache versions from their FTP site:  http://ftp.ensembl.org/pub/release-100/variation/vep/, expanding the .tar.gz, and then using zgrep to search for 'lincRNA' or 'lncRNA' in their files.  

Here is an example where I have the 'vep' version 97 and 'refseq' version 100 caches saved locally:  (note that the VEP GRCh37 are the only ones with 'lincRNA' and the others all have 'lncRNA')

```
[alanh@login:vep_cache] $ ls -d homo*/*
homo_sapiens/97_GRCh37/  homo_sapiens/97_GRCh38/  homo_sapiens_refseq/100_GRCh37/  homo_sapiens_refseq/100_GRCh38/
[alanh@login vep_cache]  $ zgrep -c lincRNA homo_sapiens*/*/5/1000*gz|grep -v ':0'
homo_sapiens/97_GRCh37/5/10000001-11000000.gz:9
homo_sapiens/97_GRCh37/5/1000001-2000000.gz:12
homo_sapiens/100_GRCh37/5/10000001-11000000.gz:9
homo_sapiens/100_GRCh37/5/1000001-2000000.gz:12
[alanh@login:vep_cache] [base] $ zgrep -c lncRNA homo_sapiens*/*/5/1000*gz|grep -v ':0'
homo_sapiens/97_GRCh38/5/100000001-101000000.gz:20
homo_sapiens/97_GRCh38/5/10000001-11000000.gz:36
homo_sapiens/97_GRCh38/5/1000001-2000000.gz:54
homo_sapiens_refseq/100_GRCh37/5/10000001-11000000.gz:4
homo_sapiens_refseq/100_GRCh37/5/1000001-2000000.gz:4
homo_sapiens_refseq/100_GRCh38/5/100000001-101000000.gz:10
homo_sapiens_refseq/100_GRCh38/5/10000001-11000000.gz:14
homo_sapiens_refseq/100_GRCh38/5/1000001-2000000.gz:13
```

The VEP test suite also refers to both "lincRNA" and some "lncRNA":  

https://github.com/Ensembl/ensembl-vep/blob/4e307dea15d2c91719bd76aae3315d438dbb072c/t/AnnotationSource_File_GFF.t