### PR TITLE
Handle new splice effects in ensembl-vep version 105

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -54,6 +54,9 @@ sub GetEffectPriority {
         'rare_amino_acid_variant' => 6, # A sequence variant whereby at least one base of a codon encoding a rare amino acid is changed, resulting in a different encoded amino acid
         'transcript_amplification' => 7, # A feature amplification of a region containing a transcript
         'splice_region_variant' => 8, # A sequence variant in which a change has occurred within the region of the splice site, either within 1-3 bases of the exon or 3-8 bases of the intron
+        'splice_donor_5th_base_variant' => 8, # A sequence variant that causes a change at the 5th base pair after the start of the intron in the orientation of the transcript
+        'splice_donor_region_variant' => 8, # A sequence variant that falls in the region between the 3rd and 6th base after splice junction (5' end of intron)
+        'splice_polypyrimidine_tract_variant' => 8, # A sequence variant that falls in the polypyrimidine tract at 3' end of intron between 17 and 3 bases from the end (acceptor -3 to acceptor -17)
         'start_retained_variant' => 9, # A sequence variant where at least one base in the start codon is changed, but the start remains
         'stop_retained_variant' => 9, # A sequence variant where at least one base in the terminator codon is changed, but the terminator remains
         'synonymous_variant' => 9, # A sequence variant where there is no resulting change to the encoded amino acid


### PR DESCRIPTION
Per https://github.com/Ensembl/ensembl-vep/releases/tag/release%2F105.0 there are 3 new effect terms in VEP that need handling.
- splice_donor_5th_base_variant (SO:0001787)
- splice_donor_region_variant (SO:0002170)
- splice_polypyrimidine_tract_variant (SO:0002169)

I set the priority to match splice_region_variant (see the severity order here: https://useast.ensembl.org/info/genome/variation/prediction/predicted_data.html).