### PR TITLE
Remove --af_esp flag as it's deprecated

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -482,7 +482,7 @@ unless( $inhibit_vep ) {
     if( $species eq "homo_sapiens" ) {
         # Slight change in options if in offline mode, or if using the newer VEP
         $vep_cmd .= " --polyphen b" . ( $vep_script =~ m/vep$/ ? " --af" : " --gmaf" );
-        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_esp --af_gnomad" : " --maf_1kg --maf_esp" ) unless( $online );
+        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_gnomad" : " --maf_1kg --maf_esp" ) unless( $online );
     }
     # Do not use the --regulatory option in situations where we know it will break
     $vep_cmd .= " --regulatory" unless( $species eq "canis_familiaris" or $online );


### PR DESCRIPTION
This flag stops vcf2maf from running with vep 107 (haven't tested it for earlier versions)