### PR TITLE
handle file names and paths which contain special characters

### DIFF
--- a/maf2maf.pl
+++ b/maf2maf.pl
@@ -102,8 +102,8 @@ else {
 }
 
 # Construct a maf2vcf command and run it
-my $maf2vcf_cmd = "$perl_bin $maf2vcf_path --input-maf $input_maf --output-dir $tmp_dir " .
-    "--ref-fasta $ref_fasta --tum-depth-col $tum_depth_col --tum-rad-col $tum_rad_col " .
+my $maf2vcf_cmd = "$perl_bin '$maf2vcf_path' --input-maf '$input_maf' --output-dir '$tmp_dir' " .
+    "--ref-fasta '$ref_fasta' --tum-depth-col $tum_depth_col --tum-rad-col $tum_rad_col " .
     "--tum-vad-col $tum_vad_col --nrm-depth-col $nrm_depth_col --nrm-rad-col $nrm_rad_col ".
     "--nrm-vad-col $nrm_vad_col --per-tn-vcfs";
 system( $maf2vcf_cmd ) == 0 or die "\nERROR: Failed to run maf2vcf! Command: $maf2vcf_cmd\n";
@@ -124,7 +124,7 @@ else {
     ( -s $vep_script ) or die "ERROR: Cannot find VEP script in path: $vep_path\n";
 
     # Contruct VEP command using some default options and run it
-    my $vep_cmd = "$perl_bin $vep_script --species $species --assembly $ncbi_build --offline --no_progress --no_stats --buffer_size $buffer_size --sift b --ccds --uniprot --hgvs --symbol --numbers --domains --gene_phenotype --canonical --protein --biotype --uniprot --tsl --pubmed --variant_class --shift_hgvs 1 --check_existing --total_length --allele_number --no_escape --xref_refseq --failed 1 --vcf --flag_pick_allele --pick_order canonical,tsl,biotype,rank,ccds,length --dir $vep_data --fasta $ref_fasta --format vcf --input_file $vcf_file --output_file $vep_anno";
+    my $vep_cmd = "$perl_bin '$vep_script' --species $species --assembly $ncbi_build --offline --no_progress --no_stats --buffer_size $buffer_size --sift b --ccds --uniprot --hgvs --symbol --numbers --domains --gene_phenotype --canonical --protein --biotype --uniprot --tsl --pubmed --variant_class --shift_hgvs 1 --check_existing --total_length --allele_number --no_escape --xref_refseq --failed 1 --vcf --flag_pick_allele --pick_order canonical,tsl,biotype,rank,ccds,length --dir '$vep_data' --fasta '$ref_fasta' --format vcf --input_file '$vcf_file' --output_file '$vep_anno'";
     # VEP barks if --fork is set to 1. So don't use this argument unless it's >1
     $vep_cmd .= " --fork $vep_forks" if( $vep_forks > 1 );
     # Require allele match for co-located variants unless user-rejected or we're using a newer VEP
@@ -148,7 +148,7 @@ else {
 my $tsv_file = $tmp_basename . ".pairs.tsv";
 
 # Store the VEP annotated VCF header so we can duplicate it for per-TN VCFs
-my $vep_vcf_header = `grep ^## $vep_anno`;
+my $vep_vcf_header = `grep ^## '$vep_anno'`;
 
 # Split the multi-sample VEP annotated VCF into per-TN VCFs
 my ( %tn_pair, %t_col_idx, %n_col_idx, %tn_vep );
@@ -163,7 +163,7 @@ while( my $line = $vep_fh->getline ) {
     if( $line =~ m/^#CHROM/ ) {
 
         # Initialize VCF header and fill up %tn_pair for each tumor-normal pair
-        foreach ( `grep -Ev ^# $tsv_file` ){
+        foreach ( `grep -Ev ^# '$tsv_file'` ){
             chomp;
             my @ids = split( "\t", $_ );
             $t_col_idx{ $ids[ 0 ] } = 1;
@@ -224,16 +224,16 @@ foreach my $tn_vcf ( @vcfs ) {
     my ( $tumor_id, $normal_id ) = $tn_vcf=~m/^.*\/(.*)_vs_(.*)\.vep.vcf/;
     my $tn_maf = $tn_vcf;
     $tn_maf =~ s/.vep.vcf$/.vep.maf/;
-    my $vcf2maf_cmd = "$perl_bin $vcf2maf_path --input-vcf $tn_vcf --output-maf $tn_maf --inhibit-vep" .
-        " --tumor-id $tumor_id --normal-id $normal_id --vep-path $vep_path --vep-data $vep_data" .
-        " --ref-fasta $ref_fasta --ncbi-build $ncbi_build --species $species --max-subpop-af $max_subpop_af";
-    $vcf2maf_cmd .= " --custom-enst $custom_enst_file" if( $custom_enst_file );
+    my $vcf2maf_cmd = "$perl_bin '$vcf2maf_path' --input-vcf '$tn_vcf' --output-maf '$tn_maf' --inhibit-vep" .
+        " --tumor-id $tumor_id --normal-id $normal_id --vep-path '$vep_path' --vep-data '$vep_data' " .
+        " --ref-fasta '$ref_fasta' --ncbi-build $ncbi_build --species $species --max-subpop-af $max_subpop_af";
+    $vcf2maf_cmd .= " --custom-enst '$custom_enst_file'" if( $custom_enst_file );
     system( $vcf2maf_cmd ) == 0 or die "\nERROR: Failed to run vcf2maf! Command: $vcf2maf_cmd\n";
 }
 
 # Fetch the column header from one of the resulting MAFs
 my @mafs = glob( "$tmp_dir/*.vep.maf" );
-my $maf_header = `grep ^Hugo_Symbol $mafs[0] | head -n1`;
+my $maf_header = `grep ^Hugo_Symbol '$mafs[0]' | head -n1`;
 chomp( $maf_header );
 
 # If user wants to retain some columns from the input MAF, fetch those and override
@@ -344,7 +344,7 @@ if( $output_maf ) {
 }
 $maf_fh->print( "#version 2.4\n$maf_header\n" );
 foreach my $tn_maf ( @mafs ) {
-    my @maf_lines = `grep -Ev "^#|^Hugo_Symbol" $tn_maf`;
+    my @maf_lines = `grep -Ev "^#|^Hugo_Symbol" '$tn_maf'`;
     $maf_fh->print( @maf_lines );
 }
 $maf_fh->close;

--- a/maf2vcf.pl
+++ b/maf2vcf.pl
@@ -78,7 +78,7 @@ while( my $line = $maf_fh->getline ) {
         # Fetch all tumor-normal paired IDs from the MAF, doing some whitespace cleanup in the same step
         my $tn_idx = $col_idx{tumor_sample_barcode} + 1;
         $tn_idx .= ( "," . ( $col_idx{matched_norm_sample_barcode} + 1 )) if( defined $col_idx{matched_norm_sample_barcode} );
-        @tn_pair = map{s/^\s+|\s+$|\r|\n//g; s/\s*\t\s*/\t/; $_}`grep -aEiv "^#|^Hugo_Symbol|^Chromosome|^Tumor_Sample_Barcode" $input_maf | cut -f $tn_idx | sort -u`;
+        @tn_pair = map{s/^\s+|\s+$|\r|\n//g; s/\s*\t\s*/\t/; $_}`grep -aEiv "^#|^Hugo_Symbol|^Chromosome|^Tumor_Sample_Barcode" '$input_maf' | cut -f $tn_idx | sort -u`;
 
         # Quit if one of the TN barcodes are missing, or they contain characters not allowed in Unix filenames
         map{ ( !m/^\s*$|^#|\0|\// ) or die "ERROR: Invalid Tumor_Sample_Barcode in MAF: \"$_\"\n"} @tn_pair;
@@ -103,7 +103,7 @@ $maf_fh->close;
 my ( @regions_split, $lines );
 my @regions = keys %uniq_regions;
 push( @regions_split, [ splice( @regions, 0, 5000 ) ] ) while @regions;
-map{ my $loci = join( " ", @{$_} ); $lines .= `$samtools faidx $ref_fasta $loci` } @regions_split;
+map{ my $loci = join( " ", @{$_} ); $lines .= `'$samtools' faidx '$ref_fasta' $loci` } @regions_split;
 foreach my $line ( grep( length, split( ">", $lines ))) {
     # Carefully split this FASTA entry, properly chomping newlines for long indels
     my ( $locus, $bps ) = split( "\n", $line, 2 );
@@ -119,8 +119,8 @@ foreach my $line ( grep( length, split( ">", $lines ))) {
 
 # Create VCF header lines for the reference FASTA, its contigs, and their lengths
 my $ref_fai = $ref_fasta . ".fai";
-`$samtools faidx $ref_fasta` unless( -s $ref_fai );
-my @ref_contigs = map { chomp; my ($chr, $len)=split("\t"); "##contig=<ID=$chr,length=$len>\n" } `cut -f1,2 $ref_fai | sort -k1,1V`;
+`'$samtools' faidx '$ref_fasta'` unless( -s $ref_fai );
+my @ref_contigs = map { chomp; my ($chr, $len)=split("\t"); "##contig=<ID=$chr,length=$len>\n" } `cut -f1,2 '$ref_fai' | sort -k1,1V`;
 my $ref_header = "##reference=file://$ref_fasta\n" . join( "", @ref_contigs );
 
 # Parse through each variant in the MAF, and fill up the respective per-sample VCFs

--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -277,7 +277,7 @@ my %custom_enst;
 if( $custom_enst_file ) {
     ( -s $custom_enst_file ) or die "ERROR: Provided --custom-enst file is missing or empty: $custom_enst_file\n";
     warn "STATUS: Reading --custom-enst $custom_enst_file...\n" if( $verbose );
-    %custom_enst = map{chomp; ( $_, 1 )}`grep -v ^# $custom_enst_file | cut -f1`;
+    %custom_enst = map{chomp; ( $_, 1 )}`grep -v ^# '$custom_enst_file' | cut -f1`;
 }
 
 # Create a folder for the intermediate VCFs if user-defined, or default to the input VCF's folder
@@ -329,7 +329,7 @@ while( my $line = $orig_vcf_fh->getline ) {
             $cols[7]=~s/SVMETHOD=([\w.]+)/Method=$1/;
             $cols[4] = "<" . $info{SVTYPE} . ">";
             # Fetch the REF allele at the second breakpoint using samtools faidx
-            my $ref2 = `$samtools faidx $ref_fasta $info{CHR2}:$info{END}-$info{END} | grep -v ^\\>`;
+            my $ref2 = `'$samtools' faidx '$ref_fasta' $info{CHR2}:$info{END}-$info{END} | grep -v ^\\>`;
             chomp( $ref2 );
             $split_vcf_fh->print( join( "\t", $info{CHR2}, $info{END}, $cols[2], ( $ref2 ? $ref2 : $cols[3] ), @cols[4..$#cols] ), "\n" );
             $split_vcf_fh->print( join( "\t", @cols ), "\n" );
@@ -357,8 +357,8 @@ if( $remap_chain ) {
     warn "STATUS: Running liftOver...\n" if( $verbose );
 
     # Make a BED file from the VCF, run liftOver on it, and create a hash mapping old to new loci
-    `grep -v ^# $input_vcf | cut -f1,2 | awk '{OFS="\\t"; print \$1,\$2-1,\$2,\$1":"\$2}' > $tmp_dir/$input_name.bed`;
-    %remap = map{chomp; my @c=split("\t"); ($c[3], "$c[0]:$c[2]")}`$liftover $tmp_dir/$input_name.bed $remap_chain /dev/stdout /dev/null 2> /dev/null`;
+    `grep -v ^# '$input_vcf' | cut -f1,2 | awk '{OFS="\\t"; print \$1,\$2-1,\$2,\$1":"\$2}' > '$tmp_dir/$input_name.bed'`;
+    %remap = map{chomp; my @c=split("\t"); ($c[3], "$c[0]:$c[2]")}`'$liftover' '$tmp_dir/$input_name.bed' '$remap_chain' /dev/stdout /dev/null 2> /dev/null`;
     unlink( "$tmp_dir/$input_name.bed" );
 
     # Create a new VCF in the temp folder, with remapped loci on which we'll run annotation
@@ -412,7 +412,7 @@ my ( $lines, @regions_split ) = ( "", ());
 my @regions = keys %uniq_regions;
 my $chr_prefix_in_use = ( @regions and $regions[0] =~ m/^chr/ ? 1 : 0 );
 push( @regions_split, [ splice( @regions, 0, $buffer_size ) ] ) while @regions;
-map{ my $region = join( " ", sort @{$_} ); $lines .= `$samtools faidx $ref_fasta $region` } @regions_split;
+map{ my $region = join( " ", sort @{$_} ); $lines .= `'$samtools' faidx '$ref_fasta' $region` } @regions_split;
 foreach my $line ( grep( length, split( ">", $lines ))) {
     # Carefully split this FASTA entry, properly chomping newlines for long indels
     my ( $region, $bps ) = split( "\n", $line, 2 );
@@ -456,7 +456,7 @@ unless( $inhibit_vep ) {
     ( -s $vep_script ) or die "ERROR: Cannot find VEP script under: $vep_path\n";
 
     # Contruct VEP command using some default options and run it
-    my $vep_cmd = "$perl_bin $vep_script --species $species --assembly $ncbi_build";
+    my $vep_cmd = "$perl_bin '$vep_script' --species $species --assembly $ncbi_build";
     $vep_cmd .= " --no_progress" unless( $verbose );
     $vep_cmd .= " --no_stats" unless( $vep_stats );
     $vep_cmd .= " --buffer_size $buffer_size --sift b --ccds";
@@ -464,7 +464,7 @@ unless( $inhibit_vep ) {
     $vep_cmd .= " --protein --biotype --uniprot --tsl --variant_class --shift_hgvs 1";
     $vep_cmd .= " --check_existing --total_length --allele_number --no_escape --xref_refseq";
     $vep_cmd .= " --failed 1 --vcf --flag_pick_allele --pick_order canonical,tsl,biotype,rank,ccds,length";
-    $vep_cmd .= " --dir $vep_data --fasta $ref_fasta --format vcf --input_file $input_vcf --output_file $output_vcf";
+    $vep_cmd .= " --dir '$vep_data' --fasta '$ref_fasta' --format vcf --input_file '$input_vcf' --output_file '$output_vcf'";
     $vep_cmd .= " --force_overwrite" if( $vep_overwrite );
     # Change options based on whether we are running in offline mode or not
     $vep_cmd .= ( $online ? " --database --host useastdb.ensembl.org" : " --offline --pubmed" );
@@ -560,7 +560,7 @@ $script_dir = "." unless( $script_dir );
 my $entrez_id_file = "$script_dir/data/ensg_to_entrez_id_map_ensembl_feb2014.tsv";
 my %entrez_id_map = ();
 if( -s $entrez_id_file ) {
-    %entrez_id_map = map{chomp; split("\t")} `grep -hv ^# $entrez_id_file`;
+    %entrez_id_map = map{chomp; split("\t")} `grep -hv ^# '$entrez_id_file'`;
 }
 
 # Parse through each variant in the annotated VCF, pull out CSQ/ANN from the INFO column, and choose

--- a/vcf2vcf.pl
+++ b/vcf2vcf.pl
@@ -96,8 +96,8 @@ if( $remap_chain ) {
     ( $liftover and -e $liftover ) or die "ERROR: Please install liftOver, and make sure it's in your PATH\n";
 
     # Make a BED file from the VCF, run liftOver on it, and create a hash mapping old to new loci
-    `grep -v ^# $input_vcf | cut -f1,2 | awk '{OFS="\\t"; print \$1,\$2-1,\$2,\$1":"\$2}' > $tmp_dir/input.bed`;
-    %remap = map{chomp; my @c=split("\t"); ($c[3], "$c[0]:$c[2]")}`$liftover $tmp_dir/input.bed $remap_chain /dev/stdout /dev/null 2> /dev/null`;
+    `grep -v ^# '$input_vcf' | cut -f1,2 | awk '{OFS="\\t"; print \$1,\$2-1,\$2,\$1":"\$2}' > '$tmp_dir/input.bed'`;
+    %remap = map{chomp; my @c=split("\t"); ($c[3], "$c[0]:$c[2]")}`'$liftover' '$tmp_dir/input.bed' '$remap_chain' /dev/stdout /dev/null 2> /dev/null`;
     unlink( "$tmp_dir/input.bed" );
 
     # Create a new VCF in the temp folder, with remapped loci
@@ -219,7 +219,7 @@ while( my $line = $vcf_in_fh->getline ) {
         $nrm_info{DP} = $nrm_info{AD} = $nrm_info{ADF} = $nrm_info{ADR} = ".";
 
         # Generate mpileup and parse out only DP,AD,ADF,ADR for tumor/normal samples
-        my @p_lines = `samtools mpileup --region $chrom:$pos-$pos --count-orphans --no-BAQ --min-MQ 1 --min-BQ 5 --ignore-RG --excl-flags UNMAP,SECONDARY,QCFAIL,DUP --VCF --uncompressed --output-tags DP,AD,ADF,ADR --ext-prob 20 --gap-frac 0.002 --tandem-qual 80 --min-ireads 1 --open-prob 30 --fasta-ref $ref_fasta $tumor_bam $normal_bam 2> /dev/null`;
+        my @p_lines = `'$samtools' mpileup --region $chrom:$pos-$pos --count-orphans --no-BAQ --min-MQ 1 --min-BQ 5 --ignore-RG --excl-flags UNMAP,SECONDARY,QCFAIL,DUP --VCF --uncompressed --output-tags DP,AD,ADF,ADR --ext-prob 20 --gap-frac 0.002 --tandem-qual 80 --min-ireads 1 --open-prob 30 --fasta-ref '$ref_fasta' '$tumor_bam' '$normal_bam' 2> /dev/null`;
 
         my ( $p_vcf_tumor_idx, $p_vcf_normal_idx ) = ( 0, 1 );
         foreach my $p_line ( @p_lines ) {


### PR DESCRIPTION
add the possibility to have filenames with special characters properly processed. Being a consortium with 20+ participating sites, we have input files naming that are out of control. Sometimes, the command fails because of a simple space or "(". With this pull request, when running the vcf2maf family of scripts, one can use the following in the command line:

contain filename in single quotes:
```--input-vcf '`-=~!@#$%^&*()_+[]\{}|;'"'"':",.<>?spaceFollows tabFollows  .vcf'```

contain filename in double quotes:
```--output-maf "\`-=~"'!'"@#$%^&*()_+[]\{}|;':"'"'",.<>?spaceFollows tabFollows  .maf"```

or let the bash do it for you:
```--remap-chain \`-\=~\!\@#\$%\^\&\*\(\)_+\[\]\\\{\}\|\;\'\:\"\,.\<\>\?spaceFollows\ tabFollows\  .chain```

Additionally, paths to samtools, liftover and tmp_dir might also contain special characters now.

Known limitations:
special chars in vep cache dir are still creating problems, but this is a VEP-problem.


