### PR TITLE
Remove deprecated VEP 110 argument

### DIFF
--- a/maf2maf.pl
+++ b/maf2maf.pl
@@ -134,7 +134,7 @@ else {
     # Add options that only work on human variants
     if( $species eq "homo_sapiens" ) {
         # Slight change in these arguments if using the newer VEP
-        $vep_cmd .= " --polyphen b " . ( $vep_script =~ m/vep$/ ? "--af --af_1kg --af_esp --af_gnomad" : "--gmaf --maf_1kg --maf_esp" );
+        $vep_cmd .= " --polyphen b " . ( $vep_script =~ m/vep$/ ? "--af --af_1kg --af_gnomad" : "--gmaf --maf_1kg --maf_esp" );
     }
     # Add options that work for most species, except a few
     $vep_cmd .= " --regulatory" unless( $species eq "canis_familiaris" );

--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -485,7 +485,7 @@ unless( $inhibit_vep ) {
     if( $species eq "homo_sapiens" ) {
         # Slight change in options if in offline mode, or if using the newer VEP
         $vep_cmd .= " --polyphen b" . ( $vep_script =~ m/vep$/ ? " --af" : " --gmaf" );
-        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_esp --af_gnomad" : " --maf_1kg --maf_esp" ) unless( $online );
+        $vep_cmd .= ( $vep_script =~ m/vep$/ ? " --af_1kg --af_gnomad" : " --maf_1kg --maf_esp" ) unless( $online );
     }
     # Do not use the --regulatory option in situations where we know it will break
     $vep_cmd .= " --regulatory" unless( $species eq "canis_familiaris" or $online );


### PR DESCRIPTION
Removes the `--af_esp` argument, which is deprecated in VEP 110, allowing maf2maf to run w/ VEP 110. 