### PR TITLE
adding plugin parameter to vcf2maf

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -1348,7 +1348,7 @@ with B<--retain-ann> to ensure they are included in the output MAF.
 
 =over 8
 
---vep-plugin AlphaMissense,file=/path/to/AlphaMissense_{build}.tsv.gz 
+--vep-plugins AlphaMissense,file=/path/to/AlphaMissense_{build}.tsv.gz 
 
 --retain-ann am_pathogenicity,am_class
 


### PR DESCRIPTION
Hi @ckandoth , I needed to be able to run the AlphaMissense VEP plugin in vcf2maf, so I made a couple of small modifications to enable vcf2maf users to pass plugin instructions to VEP's --plugin parameter. Candidly, I've only tested this with the AlphaMissense plugin, so I am not sure if it works with any other or all VEP plugins, but I imagine it should work with any of them unless they're doing something odd to the VCF file and not just adding annotations. 

Curious if you would be interested in adding this to the next vcf2maf release? Thanks!

Happy to hear any feedback or suggestions you might have as well. 