### PR TITLE
fix: avoid adding duplicate CSQ/ANN fields via `--retain-ann`

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -553,7 +553,13 @@ my @ann_cols = qw( Allele Gene Feature Feature_type Consequence cDNA_position CD
 
 # push any requested custom VEP annotations from the CSQ/ANN section into @ann_cols
 if ($retain_ann) {
-    push @ann_cols, split(',',$retain_ann);
+    my @extra_ann = split(',',$retain_ann);
+    for my $ann (@extra_ann) {
+        # make sure not to add duplicates to @ann_cols
+        if ( !($ann ~~ @ann_cols) ) {
+            push @ann_cols, $ann;
+        }
+    }
 }
 
 my @ann_cols_format; # To store the actual order of VEP data, that may differ between runs


### PR DESCRIPTION
We have cases where we want to ensure that certain `ANN` columns are in the MAF file, and we generate that list programmatically in a workflow. Currently, this leads to a duplication of any field requested via `--retain-ann`, that is already in the default list at:

https://github.com/mskcc/vcf2maf/blob/0d3f5143e9600a707079c87c59cefc5b0cd07fd2/vcf2maf.pl#L545-L552

So this solutions filters out any `--retain-add`-specified fields that are already in `@ann_cols` and avoids pushing them onto the column array.

I just looked up all the syntax and tried it in some online perl compiler. So feel free to adjust it to whichever style you might prefer. And obviously to fix any mistakes I might have made.