### PR TITLE
Add transcript biotypes to vcf2maf.pl

### DIFF
--- a/vcf2maf.pl
+++ b/vcf2maf.pl
@@ -155,6 +155,7 @@ sub GetBiotypePriority {
         'bidirectional_promoter_lncRNA' => 3, # A non-coding locus that originates from within the promoter region of a protein-coding gene, with transcription proceeding in the opposite direction on the other strand
         'known_ncrna' => 4,
         'vaultRNA' => 4, # Short non coding RNA genes that form part of the vault ribonucleoprotein complex
+        'vault_RNA' => 4,
         'macro_lncRNA' => 4, # unspliced lncRNAs that are several kb in size
         'Mt_tRNA' => 4, # Non-coding RNA predicted using sequences from RFAM and miRBase
         'Mt_rRNA' => 4, # Non-coding RNA predicted using sequences from RFAM and miRBase
@@ -184,6 +185,7 @@ sub GetBiotypePriority {
         'pseudogene' => 8, # Have homology to proteins but generally suffer from a disrupted coding sequence and an active homologous gene can be found at another locus. Sometimes these entries have an intact coding sequence or an open but truncated ORF, in which case there is other evidence used (for example genomic polyA stretches at the 3' end) to classify them as a pseudogene. Can be further classified as one of the following
         'processed_pseudogene' => 8, # Pseudogene that lack introns and is thought to arise from reverse transcription of mRNA followed by reinsertion of DNA into the genome
         'polymorphic_pseudogene' => 8, # Pseudogene owing to a SNP/DIP but in other individuals/haplotypes/strains the gene is translated
+        'protein_coding_LoF' => 8, # Not translated in the reference genome owing to a SNP/DIP but in other individuals/haplotypes/strains the transcript is translated. Replaces the polymorphic_pseudogene transcript biotype
         'retrotransposed' => 8, # Pseudogene owing to a reverse transcribed and re-inserted sequence
         'translated_processed_pseudogene' => 8, # Pseudogenes that have mass spec data suggesting that they are also translated
         'translated_unprocessed_pseudogene' => 8, # Pseudogenes that have mass spec data suggesting that they are also translated
@@ -200,6 +202,7 @@ sub GetBiotypePriority {
         'rRNA_pseudogene' => 8, # Non-coding RNAs predicted to be pseudogenes by the Ensembl pipeline
         'misc_RNA_pseudogene' => 8, # Non-coding RNAs predicted to be pseudogenes by the Ensembl pipeline
         'miRNA_pseudogene' => 8, # Non-coding RNAs predicted to be pseudogenes by the Ensembl pipeline
+        'IG_pseudogene' => 8, # Inactivated immunoglobulin gene
         'IG_C_pseudogene' => 8, # Inactivated immunoglobulin gene
         'IG_D_pseudogene' => 8, # Inactivated immunoglobulin gene
         'IG_J_pseudogene' => 8, # Inactivated immunoglobulin gene


### PR DESCRIPTION
Added 'vault_RNA' , 'protein_coding_LoF', and 'IG_pseudogene' transcript biotypes. These biotypes are present in recent Ensembl annotations.